### PR TITLE
v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-embedded",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
New release. Major because it breaks compatibility with  Ember 3.4.