### PR TITLE
Stricter TypeScript settings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,5 +90,15 @@ module.exports = {
         '@typescript-eslint/explicit-module-boundary-types': ['error'],
       },
     },
+
+    {
+      files: ['**/*.ts'],
+      rules: {
+        // These 2 rules are already covered by the TypeScript compiler (`tsc`)
+        '@typescript-eslint/no-unused-vars': 'off',
+        'no-undef': 'off',
+        'no-unused-vars': 'off',
+      },
+    },
   ],
 }

--- a/addon/initializers/embedded.ts
+++ b/addon/initializers/embedded.ts
@@ -53,7 +53,7 @@ function normalizeConfig(userConfig: GivenConfig): ObjectConfig {
       'The `embedded` config property MUST be `undefined` or an an object',
       false,
       {
-        id: 'bad-object-config',
+        id: 'ember-cli-embedded.bad-object-config',
         until: '1.0.0',
       }
     )
@@ -68,7 +68,7 @@ function normalizeConfig(userConfig: GivenConfig): ObjectConfig {
       + 'The config must now be defined in a `config` property',
       false,
       {
-        id: 'bad-object-config',
+        id: 'ember-cli-embedded.bad-object-config',
         until: '1.0.0',
       }
     )

--- a/addon/initializers/embedded.ts
+++ b/addon/initializers/embedded.ts
@@ -25,7 +25,7 @@ type GivenConfig =
   | ObjectConfig
 
 function configIsNullish(config: GivenConfig): config is NullishConfig {
-  return [null, undefined].includes(config as NullishConfig)
+  return config === null || config === undefined
 }
 
 function configIsBoolean(config: GivenConfig): config is DeprecatedBooleanConfig {

--- a/addon/initializers/embedded.ts
+++ b/addon/initializers/embedded.ts
@@ -13,19 +13,19 @@ interface ObjectConfig {
     | Record<string, unknown>
 }
 
-type VoidConfig =
+type NullishConfig =
   | null
   | undefined
 
 type DeprecatedBooleanConfig = boolean
 
 type GivenConfig =
-  | VoidConfig
+  | NullishConfig
   | DeprecatedBooleanConfig
   | ObjectConfig
 
-function configIsVoid(config: GivenConfig): config is VoidConfig {
-  return [null, undefined].includes(config as VoidConfig)
+function configIsNullish(config: GivenConfig): config is NullishConfig {
+  return [null, undefined].includes(config as NullishConfig)
 }
 
 function configIsBoolean(config: GivenConfig): config is DeprecatedBooleanConfig {
@@ -40,7 +40,7 @@ function configIsObjectUnknown(config: ObjectConfig): config is Record<string, u
 }
 
 function normalizeConfig(userConfig: GivenConfig): ObjectConfig {
-  if (configIsVoid(userConfig)) {
+  if (configIsNullish(userConfig)) {
     return {
       delegateStart: false,
       config: {},

--- a/addon/services/embedded.ts
+++ b/addon/services/embedded.ts
@@ -3,7 +3,7 @@ import { getOwner } from '@ember/application'
 
 // eslint-disable-next-line ember/no-classic-classes
 const configService = ObjectProxy.extend({
-  init(...args) {
+  init(...args: Array<Record<string, unknown>>): void {
     this.content = getOwner(this).factoryFor('config:embedded').class
     this._super(...args)
   },

--- a/tests/unit/initializers/embedded-test.ts
+++ b/tests/unit/initializers/embedded-test.ts
@@ -49,7 +49,7 @@ module('Unit | Initializer | embedded', function (hooks) {
   })
 
   test('by default, it does not change the normal behaviour', async function (this: Context, assert) {
-    assert.expect(3)
+    assert.expect(4)
 
     await this.application.boot()
 
@@ -65,14 +65,17 @@ module('Unit | Initializer | embedded', function (hooks) {
       'An empty embedded config is registered'
     )
 
-    assert.ok(
-      this.application._booted === true && this.application._readinessDeferrals === 0,
+    assert.true(this.application._booted, 'The app has booted')
+
+    assert.strictEqual(
+      this.application._readinessDeferrals,
+      0,
       'No deferral has been added'
     )
   })
 
   test('without `delegateStart`, it does not change the normal behaviour', async function (this: Context, assert) {
-    assert.expect(3)
+    assert.expect(4)
 
     this.application.register('config:environment', {
       embedded: {
@@ -94,8 +97,11 @@ module('Unit | Initializer | embedded', function (hooks) {
       'An empty embedded config is registered'
     )
 
-    assert.ok(
-      this.application._booted === true && this.application._readinessDeferrals === 0,
+    assert.true(this.application._booted, 'The app has booted')
+
+    assert.strictEqual(
+      this.application._readinessDeferrals,
+      0,
       'No deferral has been added'
     )
   })
@@ -124,7 +130,7 @@ module('Unit | Initializer | embedded', function (hooks) {
   })
 
   test('with `delegateStart`, it defers the boot of the app', function (this: Context, assert) {
-    assert.expect(3)
+    assert.expect(4)
 
     this.application.register('config:environment', {
       embedded: {
@@ -152,10 +158,11 @@ module('Unit | Initializer | embedded', function (hooks) {
       'The embedded config is not registered until the app is started'
     )
 
-    const { _booted, _readinessDeferrals } = this.application
+    assert.false(this.application._booted, 'The app has not booted')
 
-    assert.ok(
-      _booted === false && _readinessDeferrals === initialDeferrals + 1,
+    assert.strictEqual(
+      this.application._readinessDeferrals,
+      initialDeferrals + 1,
       'A deferral has been added'
     )
   })

--- a/tests/unit/initializers/embedded-test.ts
+++ b/tests/unit/initializers/embedded-test.ts
@@ -49,8 +49,6 @@ module('Unit | Initializer | embedded', function (hooks) {
   })
 
   test('by default, it does not change the normal behaviour', async function (this: Context, assert) {
-    assert.expect(4)
-
     await this.application.boot()
 
     assert.strictEqual(
@@ -75,8 +73,6 @@ module('Unit | Initializer | embedded', function (hooks) {
   })
 
   test('without `delegateStart`, it does not change the normal behaviour', async function (this: Context, assert) {
-    assert.expect(4)
-
     this.application.register('config:environment', {
       embedded: {
         delegateStart: false,
@@ -107,8 +103,6 @@ module('Unit | Initializer | embedded', function (hooks) {
   })
 
   test('without `delegateStart`, the specified config is registered', async function (assert) {
-    assert.expect(1)
-
     const myCustomConfig = {
       donald: 'duck',
     }
@@ -130,8 +124,6 @@ module('Unit | Initializer | embedded', function (hooks) {
   })
 
   test('with `delegateStart`, it defers the boot of the app', function (this: Context, assert) {
-    assert.expect(4)
-
     this.application.register('config:environment', {
       embedded: {
         delegateStart: true,
@@ -168,8 +160,6 @@ module('Unit | Initializer | embedded', function (hooks) {
   })
 
   test('with `delegateStart`, the passed config is not registered until the app is started', function (assert) {
-    assert.expect(1)
-
     const myCustomConfig = {
       donald: 'duck',
     }
@@ -195,8 +185,6 @@ module('Unit | Initializer | embedded', function (hooks) {
   })
 
   test('at manual boot, the passed config is merged into the embedded config', function (this: Context, assert) {
-    assert.expect(1)
-
     const myCustomConfig = {
       yo: 'my config',
       hey: 'sup?',
@@ -232,8 +220,6 @@ module('Unit | Initializer | embedded', function (hooks) {
   })
 
   test('at manual boot, one deferral is removed', function (this: Context, assert) {
-    assert.expect(1)
-
     this.application.register('config:environment', {
       embedded: {
         delegateStart: true,

--- a/tests/unit/initializers/embedded-test.ts
+++ b/tests/unit/initializers/embedded-test.ts
@@ -144,12 +144,6 @@ module('Unit | Initializer | embedded', function (hooks) {
       'A `start()` method has been added'
     )
 
-    assert.deepEqual(
-      this.application.resolveRegistration('config:embedded'),
-      undefined,
-      'The embedded config is not registered until the app is started'
-    )
-
     assert.false(this.application._booted, 'The app has not booted')
 
     assert.strictEqual(

--- a/tests/unit/instance-initializers/embedded-test.ts
+++ b/tests/unit/instance-initializers/embedded-test.ts
@@ -5,8 +5,16 @@ import { module, test } from 'qunit'
 import Resolver from 'ember-resolver'
 import { run } from '@ember/runloop'
 
+import type { TestContext } from 'ember-test-helpers'
+import type ApplicationInstance from '@ember/application/instance'
+
+interface Context extends TestContext {
+  TestApplication: typeof Application
+  appInstance: ApplicationInstance
+}
+
 module('Unit | Instance Initializer | embedded', function (hooks) {
-  hooks.beforeEach(function () {
+  hooks.beforeEach(function (this: Context) {
     this.TestApplication = class TestApplication extends Application {
       modulePrefix = 'random_value'
     }
@@ -24,12 +32,12 @@ module('Unit | Instance Initializer | embedded', function (hooks) {
     this.appInstance = this.application.buildInstance()
   })
 
-  hooks.afterEach(function () {
+  hooks.afterEach(function (this: Context) {
     run(this.appInstance, 'destroy')
     run(this.application, 'destroy')
   })
 
-  test('It works without config', async function (assert) {
+  test('It works without config', async function (this: Context, assert) {
     assert.expect(1)
 
     this.application.register('config:environment', {
@@ -41,7 +49,7 @@ module('Unit | Instance Initializer | embedded', function (hooks) {
     assert.ok(true, 'It does not break')
   })
 
-  test('It merges the embedded config into the `APP` config', async function (assert) {
+  test('The embedded config is merged into `APP` config', async function (this: Context, assert) {
     assert.expect(1)
 
     this.application.register('config:environment', {

--- a/tests/unit/instance-initializers/embedded-test.ts
+++ b/tests/unit/instance-initializers/embedded-test.ts
@@ -37,17 +37,22 @@ module('Unit | Instance Initializer | embedded', function (hooks) {
     run(this.application, 'destroy')
   })
 
-  test('It works without config', async function (this: Context, assert) {
+  test('It works when `embedded` config is not defined', async function (this: Context, assert) {
     this.application.register('config:environment', {
       APP: {},
     })
 
     await this.appInstance.boot()
 
-    assert.ok(true, 'It does not break')
+    assert.deepEqual(
+      this.appInstance.resolveRegistration('config:environment'),
+      {
+        APP: {},
+      }
+    )
   })
 
-  test('The embedded config is merged into `APP` config', async function (this: Context, assert) {
+  test('The `embedded` config is merged into `APP` config', async function (this: Context, assert) {
     this.application.register('config:environment', {
       APP: {},
     })
@@ -58,10 +63,13 @@ module('Unit | Instance Initializer | embedded', function (hooks) {
 
     await this.appInstance.boot()
 
-    assert.strictEqual(
-      this.appInstance.resolveRegistration('config:environment').APP.yoKey,
-      'Yo Value!',
-      'The embedded config is melded into the `APP` config'
+    assert.deepEqual(
+      this.appInstance.resolveRegistration('config:environment'),
+      {
+        APP: {
+          yoKey: 'Yo Value!',
+        },
+      }
     )
   })
 })

--- a/tests/unit/instance-initializers/embedded-test.ts
+++ b/tests/unit/instance-initializers/embedded-test.ts
@@ -38,8 +38,6 @@ module('Unit | Instance Initializer | embedded', function (hooks) {
   })
 
   test('It works without config', async function (this: Context, assert) {
-    assert.expect(1)
-
     this.application.register('config:environment', {
       APP: {},
     })
@@ -50,8 +48,6 @@ module('Unit | Instance Initializer | embedded', function (hooks) {
   })
 
   test('The embedded config is merged into `APP` config', async function (this: Context, assert) {
-    assert.expect(1)
-
     this.application.register('config:environment', {
       APP: {},
     })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "module": "es6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "noEmit": true,
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "noEmit": true,
-    "noEmitOnError": false,
+    "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
-    "alwaysStrict": true,
     "baseUrl": ".",
     "experimentalDecorators": true,
     "inlineSourceMap": true,
@@ -12,13 +11,10 @@
     "noEmit": true,
     "noEmitOnError": false,
     "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
     "noImplicitReturns": true,
-    "noImplicitThis": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "strictNullChecks": true,
-    "strictPropertyInitialization": true,
+    "strict": true,
     "target": "es2020",
     "paths": {
       "dummy/tests/*": [


### PR DESCRIPTION
## Build

### Enable TypeScript flag `strict` (#88)

Enforce a stronger TypeScript configuration by enabling all of the strict mode family options.

https://www.typescriptlang.org/tsconfig#strict :

> The `strict` flag enables a wide range of type checking behaviour that results in stronger guarantees of program correctness. Turning this on is equivalent to enabling all of the strict mode family options

### Enable TypeScript flag `noEmitOnError` (#88)

From the add-on [`ember-cli-typescript`](https://ember-cli-typescript.com/docs/ts-guide/using-ts-effectively#incremental-adoption):

> Set "noEmitOnError": true in the "compilerOptions" hash in your `tsconfig.json` – it will help a lot if you can be sure that for the parts of your app you have added types to are still correct. And you'll get nice feedback immediately when you have type errors that way!

A good way to ensure nothing is emitted if errors are still detected.

### Enable TypeScript flag `forceConsistentCasingInFileNames` (#88)

A good safeguard to make the project even more bullet-proof.

https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames

> TypeScript follows the case sensitivity rules of the file system it’s running on. This can be problematic if some developers are working in a case-sensitive file system and others aren’t. If a file attempts to import `fileManager.ts` by specifying `./FileManager.ts` the file will be found in a case-insensitive file system, but not on a case-sensitive file system.
>
> When this option is set, TypeScript will issue an error if a program tries to include a file by a casing different from the casing on disk

### Enable TypeScript flag `noImplicitOverride` (#88)

https://www.typescriptlang.org/tsconfig#noImplicitOverride

> When working with classes which use inheritance, it’s possible for a
> sub-class to get “out of sync” with the functions it overloads when
> they are renamed in the base class.
> ...
> Using `noImplicitOverride` you can ensure that the sub-classes never
> go out of sync, by ensuring that functions which override include the
> keyword `override`.


## Refactor

### Disable redundant lint rules (#88)

### Fix types definitions (#88)

### Improve arguments of deprecation warnings (#88)


## Test

### Set more accurate types definitions (#88)

### Remove logical expressions from `assert` (#88)

### Remove unnecessary `assert.expect()` (#88)