### PR TITLE
doc: add CI badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# `ember-cli-embedded` [![Travis build](https://api.travis-ci.org/xcambar/ember-cli-embedded.svg)](https://travis-ci.org/xcambar/ember-cli-embedded)
+# ember-cli-embedded
+
+[![CI](https://github.com/peopledoc/ember-cli-embedded/actions/workflows/ci.yml/badge.svg)](https://github.com/peopledoc/ember-cli-embedded/actions/workflows/ci.yml) [![Ember Observer Score](https://emberobserver.com/badges/ember-cli-embedded.svg)](https://emberobserver.com/addons/ember-cli-embedded)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 
 Makes it easier to embed your Ember application in another
 (non-Ember) app.


### PR DESCRIPTION
## Doc

- Add CI badge in the README (#97)
- Add Ember Observer Score badge in the README (#97)
- Add License badge in the README (#97)