### PR TITLE
CI - Disable `ember-try` scenario `ember-canary`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,15 +171,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ember-try-scenario: [
-          ember-lts-3.16,
-          ember-lts-3.20,
-          ember-release,
-          ember-beta,
-          ember-canary,
-          ember-default-with-jquery,
-          ember-classic
-        ]
+        ember-try-scenario:
+          - ember-lts-3.16
+          - ember-lts-3.20
+          - ember-release
+          - ember-beta
+          - ember-canary
+          - ember-default-with-jquery
+          - ember-classic
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
           - ember-lts-3.20
           - ember-release
           - ember-beta
-          - ember-canary
+          # - ember-canary
           - ember-default-with-jquery
           - ember-classic
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -38,14 +38,14 @@ module.exports = async function () {
           },
         },
       },
-      {
-        name: 'ember-canary',
-        npm: {
-          devDependencies: {
-            'ember-source': await getChannelURL('canary'),
-          },
-        },
-      },
+      // {
+      //   name: 'ember-canary',
+      //   npm: {
+      //     devDependencies: {
+      //       'ember-source': await getChannelURL('canary'),
+      //     },
+      //   },
+      // },
       // The default `.travis.yml` runs this scenario via `npm test`,
       // not via `ember try`. It's still included here so that running
       // `ember try:each` manually or from a customized CI config will run it


### PR DESCRIPTION
## CI

### Fix list of `ember-try` scenarios (#109)

When editing the list of scenarios, I came across this error:

![yaml-list](https://user-images.githubusercontent.com/47531779/127627519-4b8efd6e-cb56-44b3-85f2-8f3492a55637.png)


### Disable `ember-try` scenario `ember-canary` (#109)