### PR TITLE
Fix/ new deprecated structure

### DIFF
--- a/addon/initializers/embedded.ts
+++ b/addon/initializers/embedded.ts
@@ -57,7 +57,7 @@ function normalizeConfig(userConfig: GivenConfig): ObjectConfig {
         until: 'not defined',
         for: 'ember-cli-embedded',
         since: {
-          enabled: '1.0.0'
+          enabled: '0.5.0'
         }
       }
     )
@@ -76,7 +76,7 @@ function normalizeConfig(userConfig: GivenConfig): ObjectConfig {
         until: 'not defined',
         for: 'ember-cli-embedded',
         since: {
-          enabled: '1.0.0'
+          enabled: '0.5.0'
         }
       }
     )

--- a/addon/initializers/embedded.ts
+++ b/addon/initializers/embedded.ts
@@ -54,7 +54,11 @@ function normalizeConfig(userConfig: GivenConfig): ObjectConfig {
       false,
       {
         id: 'ember-cli-embedded.bad-object-config',
-        until: '1.0.0',
+        until: 'not defined',
+        for: 'ember-cli-embedded',
+        since: {
+          enabled: '1.0.0'
+        }
       }
     )
 
@@ -69,7 +73,11 @@ function normalizeConfig(userConfig: GivenConfig): ObjectConfig {
       false,
       {
         id: 'ember-cli-embedded.bad-object-config',
-        until: '1.0.0',
+        until: 'not defined',
+        for: 'ember-cli-embedded',
+        since: {
+          enabled: '1.0.0'
+        }
       }
     )
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/ember__array": "^3.16.4",
     "@types/ember__component": "^3.16.6",
     "@types/ember__controller": "^3.16.6",
-    "@types/ember__debug": "^3.16.4",
+    "@types/ember__debug": "^3.16.5",
     "@types/ember__engine": "^3.16.3",
     "@types/ember__error": "^3.16.1",
     "@types/ember__object": "^3.12.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,10 +1460,19 @@
   dependencies:
     "@types/ember__object" "*"
 
-"@types/ember__debug@*", "@types/ember__debug@^3.16.4":
+"@types/ember__debug@*":
   version "3.16.4"
   resolved "https://registry.yarnpkg.com/@types/ember__debug/-/ember__debug-3.16.4.tgz#b5fca2a568505f7e0a39b5ab5f489f8d32990caf"
   integrity sha512-Tlz6TB2nRbRczGa+v2+nGPvF8Cw0WRp29t3uT6Ryog6W2Alocqclsqc57EsGgLi1g4jEPP53NUI3dIJGa3AUig==
+  dependencies:
+    "@types/ember__debug" "*"
+    "@types/ember__engine" "*"
+    "@types/ember__object" "*"
+
+"@types/ember__debug@^3.16.5":
+  version "3.16.5"
+  resolved "https://registry.yarnpkg.com/@types/ember__debug/-/ember__debug-3.16.5.tgz#ce04532c100fdc1c97c9f308d69a88d6e956db97"
+  integrity sha512-Sj0idBMOd33PubBbxtXty+tzyVIAbxK4cf8q0AKZ0z5wOL0wsFOLCvMgRMxSME3DB2uvJd4u9tGr15XFM+Z03A==
   dependencies:
     "@types/ember__debug" "*"
     "@types/ember__engine" "*"


### PR DESCRIPTION
## Build

### Update `@types/ember__debug@3.16.5` (#117)

## Fixes
### New deprecated structure (#117) 
Keys `for` and `since` were added to deprecate options in order to avoid a warning. 