### PR TITLE
fix: update import path of `deprecate`

### DIFF
--- a/addon/initializers/embedded.ts
+++ b/addon/initializers/embedded.ts
@@ -1,6 +1,6 @@
 import EmberApplication from '@ember/application'
 import EmberObject from '@ember/object'
-import { deprecate } from '@ember/application/deprecations'
+import { deprecate } from '@ember/debug'
 import { run } from '@ember/runloop'
 import { get } from '@ember/object'
 


### PR DESCRIPTION
## Fix

### Update import path of `deprecate` (#120)

https://api.emberjs.com/ember/3.24/functions/@ember%2Fdebug/deprecate
