### PR TITLE
CI - Remove useless testing scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,6 @@ jobs:
           - ember-lts-3.16
           - ember-lts-3.20
           - ember-release
-          - ember-beta
           # - ember-canary
           - ember-default-with-jquery
           - ember-classic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,6 @@ jobs:
           - ember-lts-3.16
           - ember-lts-3.20
           - ember-release
-          # - ember-canary
           - ember-default-with-jquery
           - ember-classic
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -30,14 +30,6 @@ module.exports = async function () {
           },
         },
       },
-      // {
-      //   name: 'ember-canary',
-      //   npm: {
-      //     devDependencies: {
-      //       'ember-source': await getChannelURL('canary'),
-      //     },
-      //   },
-      // },
       // The default `.travis.yml` runs this scenario via `npm test`,
       // not via `ember try`. It's still included here so that running
       // `ember try:each` manually or from a customized CI config will run it

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -30,14 +30,6 @@ module.exports = async function () {
           },
         },
       },
-      {
-        name: 'ember-beta',
-        npm: {
-          devDependencies: {
-            'ember-source': await getChannelURL('beta'),
-          },
-        },
-      },
       // {
       //   name: 'ember-canary',
       //   npm: {


### PR DESCRIPTION
## Chore

### Remove old references to Ember.js canary (#122)

## CI

### Stop running tests for Ember.js beta (#122)