### PR TITLE
Release v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-embedded",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Control how your Ember applications boot in non-Ember pages/apps.",
   "homepage": "https://github.com/peopledoc/ember-cli-embedded",
   "keywords": [


### PR DESCRIPTION
## Breaking changes

### Refactor to Typescript (#44)

### Complete rewrite of the add-on in Ember.js v3.24 (#74)


## Build

### Stricter TypeScript settings (#88)

### Upgrade `@ember/test-helpers@2.2.9` (#108)

### Disable scenario `ember-canary` (#109)


## CI

### Remove useless testing scenarios (#122)

### Update `ember-try` scenarios with Ember 3.24 LTS and Embroider tests (#121)


## Docs

### Fix typo in `README` (#14)

### Add sections `Contributing` and `Compatibility` to README (#77)

### Move to GitHub Actions (#96)

### Add CI badge in the `README` (#97)

### Update and modernise `README` (#127)


## Fix

### Update import path of `deprecate` (#120)


## Refactor

### Update info in `package.json` (#76)

### Add TypeScript types for `qunit-dom` (#101)

### Set up TypeScript lint (#102)


## Dependabot

### Create initial configuration file (#18)

### Only ignore updates of `ember-cli` (#35)

### Update config file with the new syntax (#41)

### Bump `lodash` from 4.17.4 to 4.17.19 (#45)

### Bump `acorn` from 5.7.3 to 5.7.4 (#47)

### Bump `underscore.string` from 3.3.4 to 3.3.5 (#48)

### Bump `websocket-extensions` from 0.1.3 to 0.1.4 (#49)

### Bump `elliptic` from 6.5.2 to 6.5.3 (#52)

### Bump `npm-user-validate` from 1.0.0 to 1.0.1 (#54)

### Bump `ember-cli-babel` from 7.21.0 to 7.23.0 (#55)

### Bump `@types/ember__test-helpers` from 1.7.0 to 1.7.3 (#58)

### Bump `bl` from 1.2.2 to 1.2.3 (#59)

### Bump `@ember/optional-features` from 1.3.0 to 2.0.0 (#60)

### Bump `ember-source-channel-url` from 2.0.1 to 3.0.0 (#61)

### Bump `ember-load-initializers` from 2.1.1 to 2.1.2 (#62)

### Bump `ini` from 1.3.5 to 1.3.8 (#63)

### Bump `typescript` from 3.9.6 to 4.1.3 (#65)

### Bump `socket.io` from 2.3.0 to 2.4.1 (#67)

### Bump `ember-cli-htmlbars` from 4.3.1 to 5.3.2 (#68)

### Bump `qunit-dom` from 0.9.2 to 1.6.0 (#69)

### Bump `ember-source` from 3.19.0 to 3.25.1 (#70)

### Bump `elliptic` from 6.5.3 to 6.5.4 (#72)

### Bump `typescript` from 4.2.4 to 4.3.2 (#85)

### Bump `ws` from 7.4.5 to 7.4.6 (#87)

### Bump `eslint` from 7.26.0 to 7.27.0 (#90)

### Bump `@ember/test-helpers` from 2.2.5 to 2.2.6 (#91)

### Bump `eslint` from 7.27.0 to 7.29.0 (#93)

### Bump `eslint-plugin-ember` from 10.4.2 to 10.5.1 (#95)

### Bump `typescript` from 4.3.2 to 4.3.5 (#99)

### Bump `ember-cli-typescript` from 4.1.0 to 4.2.1 (#100)

### Bump `@types/ember__component` from 3.16.5 to 3.16.6 (#103)

### Bump `@types/ember__test-helpers` from 2.0.0 to 2.0.1 (#104)

### Bump `@types/ember__debug` from 3.16.3 to 3.16.4 (#105)

### Bump `@types/qunit` from 2.11.1 to 2.11.2 (#106)

### Bump `@types/rsvp` from 4.0.3 to 4.0.4 (#107)

### Bump `ember-cli-inject-live-reload` from 2.0.2 to 2.1.0 (#110)

### Bump `@types/ember__engine` from 3.16.2 to 3.16.3 (#111)

### Bump `@types/ember__application` from 3.16.2 to 3.16.3 (#112)

### Bump `ember-template-lint` from 3.4.2 to 3.5.1 (#113)

### Bump `path-parse` from 1.0.6 to 1.0.7 (#114)

### Bump `@ember/test-helpers` from 2.2.9 to 2.4.0 (#115)

### Bump `@types/ember-qunit` from 3.4.13 to 3.4.14 (#116)

### Bump `@types/ember__routing` from 3.16.14 to 3.16.15 (#118)

### Bump `@types/ember__controller` from 3.16.4 to 3.16.6 (#124)

### Bump `qunit` from 2.15.0 to 2.17.0 (#125)
