### PR TITLE
build: release v2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-embedded",
   "description": "Control how your Ember applications boots in non-Ember pages/apps.",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "license": "MIT",
   "author": {
     "name": "PeopleDoc",


### PR DESCRIPTION
## Build

#### Bump `@embroider/test-setup` from 0.47.0 to 0.47.1 (#166)

#### Bump `ember-cli-htmlbars` from 5.7.1 to 6.0.0 (#167)

#### Update `ember-cli` to 3.28.3 (#168)

#### Deduplicate packages (#168)

See https://github.com/atlassian/yarn-deduplicate.


## Chore

#### Refine information in `package.json` (#169)

#### Add contributors to README (#171)


## CI

#### Run workflow `tag-release-publish` only after lint & tests passed (#163)

Make the workflow `tag-release-publish` waits for the workflow `CI` to finish, so that they run sequentially (the same way jobs' steps are run sequentially).

#### Ensure only 1 workflow runs at a time (#163)

Surprisingly, while a new run of the workflow is triggered when pushing new changes, any previous workflow still running is not cancelled, resulting in a waste of resources.

We now use the `concurrency` setting to ensure that only a single workflow, using the same concurrency group, will run at a time.

#### Lint `yarn.lock` file to spot malicious attacks (#163)

- https://snyk.io/blog/why-npm-lockfiles-can-be-a-security-blindspot-for-injecting-malicious-modules
- https://github.com/lirantal/lockfile-lint

#### Fix empty concurrency group's name (#165)

Previously the concurrency group's name was empty when running on `master` ([see the faulty run](https://github.com/peopledoc/ember-cli-embedded/actions/runs/1398906462)) because the context `${{ github.head_ref }}` [is only available in PR-related events](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context).

The group's name is now prefixed with `ci-` to ensure it will never be empty.

#### Reuse organisation's workflow to run lint & tests (#168)

#### Reuse organisation's workflow to run tag & publish (#168)

#### Stop testing against Ember.js v3.16 (#168)

This version has been discontinued in August 2020 and is no longer maintained:
https://emberjs.com/releases/lts/
